### PR TITLE
refactor: simplify props function

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,4 @@
 /**
- * Internal dependencies
- */
-import getPath from './get-path';
-
-/**
  * Function returning a DOM document created by `createHTMLDocument`. The same
  * document is returned between invocations.
  *
@@ -78,8 +73,8 @@ export function prop(selector, name) {
 			match = node.querySelector(selector);
 		}
 
-		if (match) {
-			return getPath(match, name);
+		if (match && name in match) {
+			return match[name];
 		}
 	};
 }


### PR DESCRIPTION
@aduth is `getPath` necessary?

It looks like it's only ever used to look up a single key of "attributes". In PR #18  It's difficult to type as `path` should be some sort of nested `keyof` type, but there is no way to do that with a dot separated list. It is probably possible with an array of keys. But again, if getPath can be replace with the following, it makes typing `props` much simpler:

```js
export function prop(selector, name) {
	if (1 === arguments.length) {
		name = selector;
		selector = undefined;
	}

	return function (node) {
		let match = node;
		if (selector) {
			match = node.querySelector(selector);
		}

		if (match && name in match) {
			return match[name];
		}
	};
}
```

Does this fundamentally change how the library is use in real life? Does any consumer of the package use a dot separated list to access nested properties? 

The I don't see any where in documentation this feature is mentioned.